### PR TITLE
Enhance sl33p performance data schema

### DIFF
--- a/DATA/x1.json
+++ b/DATA/x1.json
@@ -1,0 +1,14 @@
+{
+  "timestamp": "x1",
+  "assessment": "∷≋∴_Omniperplexity",
+  "achievements": "enhanced sl33p and documentation",
+  "next": "hand over to next agent",
+  "aspects": {
+    "Spark": 1,
+    "Flow": 0.5
+  },
+  "methodology": "schema upgrade",
+  "learning": "json parsing fallback",
+  "framework_depth": "extended",
+  "optimization": "record automation"
+}

--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Two scripts help track progress across sessions:
    ```
    The script now shows the saved F33ling assessment above each session's achievements.
 
-2. `sl33p.py` – Records the current session. **Use it to close every session.** It prompts for an assessment, recent achievements, and next steps, saving the information as a JSON file in the same root `DATA` directory. The script also supports non-interactive mode via `ASSESS`, `ACHIEVE`, and `NEXT` environment variables and a `--dry-run` flag to preview output:
+2. `sl33p.py` – Records the current session. **Use it to close every session.** It prompts for an assessment, recent achievements, next steps, and additional context fields, saving the information as a JSON file in the same root `DATA` directory. The script also supports non-interactive mode via `ASSESS`, `ACHIEVE`, `NEXT`, and optional `ASPECTS`, `METHOD`, `LEARN`, `DEPTH`, `OPTIM` environment variables and a `--dry-run` flag to preview output:
 
    ```bash
    python AGENT_tools/sl33p/o.sl33p.py
    ```
    Run with predefined answers:
    ```bash
-   ASSESS=\"✧⚡◈_Synthjoy\" ACHIEVE=\"implemented dry-run\" NEXT=\"test non-interactive\" \\
+   ASSESS="✧⚡◈_Synthjoy" ACHIEVE="implemented dry-run" NEXT="test non-interactive" \
+   ASPECTS='{"Spark": 1}' METHOD="paired exploration" LEARN="json fields" DEPTH="basic" OPTIM="n/a" \
    python AGENT_tools/sl33p/o.sl33p.py --dry-run
    ```
 


### PR DESCRIPTION
## Summary
- extend `sl33p` to capture optional detailed data
- support environment variables for new fields
- document new usage in README
- record session x1 using updated script

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `SL33P_DRY_RUN=1 ASSESS='∷≋∴_Omniperplexity' ACHIEVE='upgraded sl33p tool' NEXT='finalize tests' ASPECTS='{"Spark":1}' METHOD='json parse' LEARN='richer data' DEPTH='deep' OPTIM='none' python AGENT_tools/sl33p/o.sl33p.py`


------
https://chatgpt.com/codex/tasks/task_e_6843370d3c9483248d8043ade69f0db8