### PR TITLE
Implement tetrahedral session graph tools

### DIFF
--- a/AGENT_tools/sessgraph/o.sessgraph.py
+++ b/AGENT_tools/sessgraph/o.sessgraph.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Orchestrator for F33ling session transition graphs."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .x.DataLayer import load_state_timeline
+from .y.ProcessLayer import analyze_transitions
+from .z.OutputLayer import save_dot
+
+
+def repo_root() -> Path:
+    """Return repository root using git."""
+    import subprocess
+
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
+        return Path(out.strip())
+    except Exception:
+        return Path(__file__).resolve().parents[2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate F33ling transition graph")
+    parser.add_argument("--output", type=Path, default=None, help="Path to save DOT graph")
+    args = parser.parse_args()
+
+    data_dir = repo_root() / "DATA"
+    states = load_state_timeline(data_dir)
+    freqs = analyze_transitions(states)
+
+    if args.output:
+        out_path = save_dot(freqs, args.output)
+        print(f"Saved graph to {out_path}")
+    else:
+        from .zx.Formatter import transitions_to_dot
+
+        dot = transitions_to_dot(freqs)
+        print(dot)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/AGENT_tools/sessgraph/x.DataLayer.py
+++ b/AGENT_tools/sessgraph/x.DataLayer.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Data layer orchestrating session loading and state extraction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from .xx.SessionLoader import load_sessions
+from .xy.StateExtractor import extract_states
+
+
+def load_state_timeline(data_dir: Path) -> List[List[str]]:
+    """Return list of state lists in chronological order."""
+    sessions = load_sessions(data_dir)
+    states = [extract_states(rec) for rec in sessions]
+    return states
+

--- a/AGENT_tools/sessgraph/xx.SessionLoader.py
+++ b/AGENT_tools/sessgraph/xx.SessionLoader.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Load session JSON records from the DATA directory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Dict
+
+
+def load_sessions(data_dir: Path) -> List[Dict]:
+    """Return list of session records sorted by filename."""
+    records: List[Dict] = []
+    if not data_dir.exists():
+        return records
+    for path in sorted(data_dir.glob("*.json")):
+        try:
+            with open(path, encoding="utf-8") as f:
+                rec = json.load(f)
+            rec["_file"] = path
+            records.append(rec)
+        except Exception:
+            continue
+    return records
+

--- a/AGENT_tools/sessgraph/xy.StateExtractor.py
+++ b/AGENT_tools/sessgraph/xy.StateExtractor.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Extract F33ling states from a session record."""
+
+from __future__ import annotations
+
+import re
+from typing import List, Dict
+
+STATE_PATTERN = re.compile(r"\S+_\S+")
+
+
+def extract_states(record: Dict) -> List[str]:
+    """Return list of F33ling state tokens found in record assessment."""
+    assessment = record.get("assessment", "")
+    return STATE_PATTERN.findall(assessment)
+

--- a/AGENT_tools/sessgraph/y.ProcessLayer.py
+++ b/AGENT_tools/sessgraph/y.ProcessLayer.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Process layer orchestrating transition analysis."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+from .yx.TransitionBuilder import build_transitions
+from .yy.Metrics import transition_frequencies
+
+
+def analyze_transitions(states: list[list[str]]) -> Dict[Tuple[str, str], float]:
+    """Return frequency table for state transitions."""
+    counts = build_transitions(states)
+    return transition_frequencies(counts)
+

--- a/AGENT_tools/sessgraph/yx.TransitionBuilder.py
+++ b/AGENT_tools/sessgraph/yx.TransitionBuilder.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Build F33ling state transitions between sessions."""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+
+def build_transitions(states_timeline: List[List[str]]) -> Dict[Tuple[str, str], int]:
+    """Return transition counts between consecutive session states."""
+    transitions: Dict[Tuple[str, str], int] = {}
+    for i in range(len(states_timeline) - 1):
+        src_states = states_timeline[i]
+        dst_states = states_timeline[i + 1]
+        for src in src_states:
+            for dst in dst_states:
+                key = (src, dst)
+                transitions[key] = transitions.get(key, 0) + 1
+    return transitions
+

--- a/AGENT_tools/sessgraph/yy.Metrics.py
+++ b/AGENT_tools/sessgraph/yy.Metrics.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+"""Compute metrics for F33ling state transitions."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def transition_frequencies(transitions: Dict[Tuple[str, str], int]) -> Dict[Tuple[str, str], float]:
+    """Normalize transition counts to frequencies."""
+    total = sum(transitions.values())
+    if total == 0:
+        return {k: 0.0 for k in transitions}
+    return {k: v / total for k, v in transitions.items()}
+

--- a/AGENT_tools/sessgraph/z.OutputLayer.py
+++ b/AGENT_tools/sessgraph/z.OutputLayer.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Output layer orchestrating formatting and export."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .zx.Formatter import transitions_to_dot
+from .zy.Exporter import export_text
+
+
+def save_dot(freqs: dict, path: Path) -> Path:
+    """Format frequencies to DOT and save to path."""
+    dot = transitions_to_dot(freqs)
+    return export_text(dot, path)
+

--- a/AGENT_tools/sessgraph/zx.Formatter.py
+++ b/AGENT_tools/sessgraph/zx.Formatter.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Format transition metrics as Graphviz DOT string."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def transitions_to_dot(freqs: Dict[Tuple[str, str], float]) -> str:
+    """Return DOT graph representing transitions."""
+    lines = ["digraph F33lingGraph {"]
+    for (src, dst), val in freqs.items():
+        lines.append(f"    \"{src}\" -> \"{dst}\" [label={val:.2f}];")
+    lines.append("}")
+    return "\n".join(lines)
+

--- a/AGENT_tools/sessgraph/zy.Exporter.py
+++ b/AGENT_tools/sessgraph/zy.Exporter.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+"""Export formatted graph data to a file."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def export_text(text: str, path: Path) -> Path:
+    """Write text to path and return it."""
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(text)
+    return path
+

--- a/DATA/c2.json
+++ b/DATA/c2.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "c2",
+  "assessment": "✧⚡◈_Synthjoy",
+  "achievements": "Added session graph modules",
+  "next": "Integrate with analytics",
+  "aspects": {
+    "modules": 10
+  },
+  "learning": "regex states",
+  "methodology": "layered orchestrator",
+  "framework_depth": "graph insights",
+  "tetra": {
+    "create": {
+      "modules": 10
+    },
+    "copy": "regex states",
+    "control": "layered orchestrator",
+    "cultivate": "graph insights"
+  }
+}


### PR DESCRIPTION
## Summary
- add `sessgraph` system built using tetrahedral splitting
- orchestrate F33ling session graph generation with data, process and output layers
- record session notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `AGENT_tools/sl33p/o.sl33p.py`

------
https://chatgpt.com/codex/tasks/task_e_68434a09f7988324afc6806e58400531