### PR TITLE
Integrate improved video search with w4k3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/AGENT_tools/sl33p/o.sl33p.py
+++ b/AGENT_tools/sl33p/o.sl33p.py
@@ -159,6 +159,7 @@ def git_commit(file_path: Path, ts: str) -> None:
 def main():
     parser = argparse.ArgumentParser(description="Record session")
     parser.add_argument("--dry-run", action="store_true", help="Preview without saving")
+    parser.add_argument("--video", type=Path, help="update video memory at path")
     args = parser.parse_args()
 
     ensure_data_dir()
@@ -173,6 +174,7 @@ def main():
     control = os.getenv("CONTROL") or os.getenv("METHOD") or os.getenv("OPTIM")
     cultivate = os.getenv("CULTIVATE") or os.getenv("DEPTH")
     optimization = os.getenv("OPTIM")
+    video_path = args.video or os.getenv("VIDMEM")
 
     if not (assessment and achievements and next_steps):
         (
@@ -219,6 +221,18 @@ def main():
             print(f"Dry run complete for {ts}.json")
         else:
             print(f"Session recorded as {ts}.json")
+            if video_path:
+                try:
+                    import importlib.util
+                    vid_path = repo_root() / "AGENT_tools" / "vidmem" / "o.vidmem.py"
+                    spec = importlib.util.spec_from_file_location("vid_loader", vid_path)
+                    mod = importlib.util.module_from_spec(spec)
+                    assert spec and spec.loader
+                    spec.loader.exec_module(mod)
+                    encode = mod._load_module("z.OutputLayer", "vidmem_z").encode
+                    encode(DATA_DIR, Path(video_path))
+                except Exception as e:  # pragma: no cover - optional dependency
+                    print(f"Video update failed: {e}")
 
 if __name__ == "__main__":
     main()

--- a/AGENT_tools/vidmem/o.vidmem.py
+++ b/AGENT_tools/vidmem/o.vidmem.py
@@ -44,6 +44,7 @@ def main() -> None:
     q = sub.add_parser("search", help="Search video with query")
     q.add_argument("video", type=Path)
     q.add_argument("query")
+    q.add_argument("--limit", type=int, default=3, help="number of results")
 
     args = parser.parse_args()
 
@@ -51,8 +52,9 @@ def main() -> None:
         out = encode(args.data_dir, args.video)
         print(f"Saved video to {out}")
     else:
-        result, score = search(args.video, args.query)
-        print(f"Best match ({score:.2f}): {result}")
+        matches = search(args.video, args.query, args.limit)
+        for text, score in matches:
+            print(f"{score:.2f} -> {text}")
 
 
 if __name__ == "__main__":

--- a/AGENT_tools/vidmem/x.DataLayer.py
+++ b/AGENT_tools/vidmem/x.DataLayer.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import List
+import base64
+import zlib
 
 import qrcode
 import cv2
@@ -18,8 +20,10 @@ def encode_sessions(data_dir: Path, out_video: Path, fps: int = 1) -> Path:
         raise FileNotFoundError("no session files found")
     frames: List[np.ndarray] = []
     for f in files:
-        text = f.read_text()
-        img = qrcode.make(text)
+        data = f.read_bytes()
+        compressed = zlib.compress(data)
+        b64 = base64.b64encode(compressed).decode("ascii")
+        img = qrcode.make(b64)
         frame = np.array(img.convert("RGB"))
         frames.append(frame)
 

--- a/AGENT_tools/vidmem/z.OutputLayer.py
+++ b/AGENT_tools/vidmem/z.OutputLayer.py
@@ -4,10 +4,29 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Tuple
+from typing import List, Tuple
 
-from .x.DataLayer import encode_sessions
-from .y.ProcessLayer import search_video
+try:
+    if __package__:
+        from .x.DataLayer import encode_sessions
+        from .y.ProcessLayer import search_video
+    else:  # support standalone execution via o.vidmem
+        raise ImportError
+except ImportError:  # fallback manual loader
+    import importlib.util
+    import sys
+    from pathlib import Path as _P
+
+    base = _P(__file__).resolve().parent
+    for mod in ["x.DataLayer", "y.ProcessLayer"]:
+        path = base / f"{mod}.py"
+        spec = importlib.util.spec_from_file_location(mod, path)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        sys.modules[mod] = module
+        spec.loader.exec_module(module)
+    from x.DataLayer import encode_sessions  # type: ignore
+    from y.ProcessLayer import search_video  # type: ignore
 
 
 def encode(data_dir: Path, out_video: Path) -> Path:
@@ -15,6 +34,6 @@ def encode(data_dir: Path, out_video: Path) -> Path:
     return encode_sessions(data_dir, out_video)
 
 
-def search(video: Path, query: str) -> Tuple[str, float]:
-    """Search query in video and return best match and score."""
-    return search_video(video, query)
+def search(video: Path, query: str, limit: int = 3) -> List[Tuple[str, float]]:
+    """Return matches for ``query`` sorted by similarity."""
+    return search_video(video, query, limit)

--- a/AGENT_tools/w4k3/o.w4k3.py
+++ b/AGENT_tools/w4k3/o.w4k3.py
@@ -5,9 +5,11 @@ Reads the 3 most recent session records from DATA folder and displays
 previous achievements and focus areas.
 """
 
+import argparse
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 # Store all session records in the repository-level DATA directory
@@ -24,7 +26,67 @@ def repo_root() -> Path:
         return Path(__file__).resolve().parents[2]
 
 
-DATA_DIR = repo_root() / "DATA"
+ROOT = repo_root()
+sys.path.insert(0, str(ROOT))
+DATA_DIR = ROOT / "DATA"
+
+def load_video_records(video: Path, n: int = 3):
+    """Decode JSON session records from ``video`` and return last ``n``."""
+    try:
+        import importlib.util
+        vid_path = ROOT / "AGENT_tools" / "vidmem" / "o.vidmem.py"
+        spec = importlib.util.spec_from_file_location("vid_loader", vid_path)
+        mod = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(mod)
+        decode_frames = mod._load_module("y.ProcessLayer", "vidmem_y").decode_frames
+    except Exception as e:  # pragma: no cover - optional dependency
+        print(f"Failed to load video decoder: {e}")
+        return []
+    if not video.exists():
+        print(f"Video memory {video} not found")
+        return []
+    try:
+        texts = decode_frames(video)
+    except Exception as e:
+        print(f"Failed to decode {video}: {e}")
+        return []
+    records = []
+    for text in texts[-n:]:
+        try:
+            records.append(json.loads(text))
+        except Exception as e:
+            print(f"Failed to parse frame: {e}")
+    return records
+
+def search_video_records(video: Path, query: str, limit: int = 3):
+    """Return records matching ``query`` ordered by relevance."""
+    try:
+        import importlib.util
+        vid_path = ROOT / "AGENT_tools" / "vidmem" / "o.vidmem.py"
+        spec = importlib.util.spec_from_file_location("vid_loader", vid_path)
+        mod = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(mod)
+        search_video = mod._load_module("y.ProcessLayer", "vidmem_y").search_video
+    except Exception as e:
+        print(f"Failed to load video searcher: {e}")
+        return []
+    if not video.exists():
+        print(f"Video memory {video} not found")
+        return []
+    try:
+        results = search_video(video, query, limit)
+    except Exception as e:
+        print(f"Failed to search {video}: {e}")
+        return []
+    records = []
+    for text, _ in results:
+        try:
+            records.append(json.loads(text))
+        except Exception as e:
+            print(f"Failed to parse frame: {e}")
+    return records
 
 def load_records(n=3):
     if not DATA_DIR.exists():
@@ -89,7 +151,22 @@ def display(records):
             print(f"  Optimization: {rec['optimization']}")
 
 def main():
-    records = load_records()
+    parser = argparse.ArgumentParser(description="Display recent session records")
+    parser.add_argument("--video", type=Path, help="optional video memory file")
+    parser.add_argument("-n", type=int, default=3, help="number of records")
+    parser.add_argument("--query", help="search video for query")
+    args = parser.parse_args()
+
+    if args.query:
+        if not args.video:
+            print("--video is required for querying")
+            records = []
+        else:
+            records = search_video_records(args.video, args.query, args.n)
+    elif args.video:
+        records = load_video_records(args.video, args.n)
+    else:
+        records = load_records(args.n)
     display(records)
 
 if __name__ == "__main__":

--- a/DATA/h2.json
+++ b/DATA/h2.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "h2",
+  "assessment": "✧⚡◈_Synthjoy",
+  "achievements": "integrated vidmem with w4k3 and sl33p",
+  "next": "refine search scoring",
+  "aspects": {
+    "VidMem": "integration"
+  },
+  "learning": "compression",
+  "methodology": "workflow link",
+  "framework_depth": "session continuity",
+  "tetra": {
+    "create": {
+      "VidMem": "integration"
+    },
+    "copy": "compression",
+    "control": "workflow link",
+    "cultivate": "session continuity"
+  }
+}

--- a/DATA/i2.json
+++ b/DATA/i2.json
@@ -1,0 +1,20 @@
+{
+  "timestamp": "i2",
+  "assessment": "✧⚡◈_Synthjoy",
+  "achievements": "improved video search and Git LFS",
+  "next": "validate full history queries",
+  "aspects": {
+    "VidMem": "search"
+  },
+  "learning": "relevance scoring",
+  "methodology": "Git LFS",
+  "framework_depth": "context recall",
+  "tetra": {
+    "create": {
+      "VidMem": "search"
+    },
+    "copy": "relevance scoring",
+    "control": "Git LFS",
+    "cultivate": "context recall"
+  }
+}

--- a/DATA/vidmem.mp4
+++ b/DATA/vidmem.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:037340811ba5df6c188191a0d9efa4585a610fc54fa7fda8d07cc51e3b88db11
+size 469810


### PR DESCRIPTION
## Summary
- add Git LFS tracking for video archives
- expand vidmem search to return top matches
- expose `--query` option in w4k3
- print multiple results in vidmem CLI
- record session i2

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python AGENT_tools/vidmem/o.vidmem.py encode DATA DATA/vidmem.mp4`
- `python AGENT_tools/w4k3/o.w4k3.py --video DATA/vidmem.mp4 -n 2`
- `python AGENT_tools/w4k3/o.w4k3.py --video DATA/vidmem.mp4 --query "video memory proto" -n 2`


------
https://chatgpt.com/codex/tasks/task_e_684378c3080c83248088df22c3f6eae0