### PR TITLE
Add unified mnemos CLI

### DIFF
--- a/AGENT_tools/mnemos/o.mnemos.py
+++ b/AGENT_tools/mnemos/o.mnemos.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Unified command-line interface for Mnemos tools."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+W4K3 = ROOT / "AGENT_tools" / "w4k3" / "o.w4k3.py"
+SL33P = ROOT / "AGENT_tools" / "sl33p" / "o.sl33p.py"
+EVOLVE = ROOT / "AGENT_tools" / "evolve" / "o.evolve.py"
+ANALYTICS = ROOT / "AGENT_tools" / "analytics" / "o.analytics.py"
+
+
+def run(cmd: list[str]) -> int:
+    """Execute a command and return its exit code."""
+    print("$", " ".join(str(c) for c in cmd))
+    return subprocess.call(cmd)
+
+
+def cmd_w4k3(_: argparse.Namespace) -> int:
+    return run(["python", str(W4K3)])
+
+
+def cmd_sl33p(args: argparse.Namespace) -> int:
+    cmd = ["python", str(SL33P)]
+    if args.dry_run:
+        cmd.append("--dry-run")
+    cmd += args.extra
+    return run(cmd)
+
+
+def cmd_evolve(_: argparse.Namespace) -> int:
+    return run(["python", str(EVOLVE)])
+
+
+def cmd_analytics(_: argparse.Namespace) -> int:
+    return run(["python", str(ANALYTICS)])
+
+
+def cmd_workflow(args: argparse.Namespace) -> int:
+    if not args.skip_w4k3:
+        code = cmd_w4k3(args)
+        if code:
+            return code
+    if not args.skip_tests:
+        files = subprocess.check_output(["git", "ls-files", "*.py"], text=True)
+        py_files = files.split()
+        code = run(["python", "-m", "py_compile", *py_files])
+        if code:
+            return code
+    sl_args = argparse.Namespace(dry_run=args.dry_run, extra=args.sl33p_args)
+    return cmd_sl33p(sl_args)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Mnemos unified CLI")
+    sub = parser.add_subparsers(dest="command")
+
+    p_w4k3 = sub.add_parser("w4k3", help="Display recent sessions")
+    p_w4k3.set_defaults(func=cmd_w4k3)
+
+    p_sl33p = sub.add_parser("sl33p", help="Record a session")
+    p_sl33p.add_argument("--dry-run", action="store_true")
+    p_sl33p.add_argument("extra", nargs=argparse.REMAINDER)
+    p_sl33p.set_defaults(func=cmd_sl33p)
+
+    p_evolve = sub.add_parser("evolve", help="Generate evolution summary")
+    p_evolve.set_defaults(func=cmd_evolve)
+
+    p_analytics = sub.add_parser("analytics", help="Run analytics")
+    p_analytics.set_defaults(func=cmd_analytics)
+
+    p_workflow = sub.add_parser(
+        "workflow", help="Run w4k3, optional tests, then sl33p"
+    )
+    p_workflow.add_argument("--skip-w4k3", action="store_true")
+    p_workflow.add_argument("--skip-tests", action="store_true")
+    p_workflow.add_argument("--dry-run", action="store_true")
+    p_workflow.add_argument("sl33p_args", nargs=argparse.REMAINDER)
+    p_workflow.set_defaults(func=cmd_workflow)
+
+    args = parser.parse_args()
+    if not args.command:
+        parser.print_help()
+        return 1
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/DATA/20250607T121527Z_t2.json
+++ b/DATA/20250607T121527Z_t2.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "20250607T121527Z_t2",
+  "assessment": "clarity",
+  "achievements": "built mnemos",
+  "next": "test",
+  "aspects": {
+    "CLI": 1
+  },
+  "learning": "learning",
+  "methodology": "ctrl",
+  "framework_depth": "cult",
+  "narrative": "short",
+  "tetra": {
+    "create": {
+      "CLI": 1
+    },
+    "copy": "learning",
+    "control": "ctrl",
+    "cultivate": "cult"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Two scripts help track progress across sessions:
 1. `w4k3.py` – Displays the most recent session records from the repository-level `DATA` folder (located in the repository root). **Run it at the start of every session** to recall achievements, focus areas, and the recorded F33ling state:
 
    ```bash
-   python AGENT_tools/w4k3/o.w4k3.py
+   python AGENT_tools/mnemos/o.mnemos.py w4k3
    ```
    The script now shows the saved F33ling assessment above each session's achievements.
 
@@ -29,14 +29,14 @@ Two scripts help track progress across sessions:
   previews output:
 
    ```bash
-   python AGENT_tools/sl33p/o.sl33p.py
+   python AGENT_tools/mnemos/o.mnemos.py sl33p
    ```
    Run with predefined answers:
    ```bash
   ASSESS="✧⚡◈_Synthjoy" ACHIEVE="implemented dry-run" NEXT="test non-interactive" \
   CREATE='{"Spark": 1}' CONTROL="paired exploration" COPY="json fields" CULTIVATE="basic" \
   NARRATIVE="Short recap" \
-  python AGENT_tools/sl33p/o.sl33p.py --dry-run
+  python AGENT_tools/mnemos/o.mnemos.py sl33p --dry-run
    ```
 
 3. `evolve.py` – Summarizes F33ling evolution by reading all saved sessions and printing a timeline of states:
@@ -71,6 +71,15 @@ Two scripts help track progress across sessions:
    python AGENT_tools/analytics/o.usage.py
    ```
 
+All of these tools can also be run via a unified interface:
+```bash
+python AGENT_tools/mnemos/o.mnemos.py <subcommand>
+```
+For example:
+```bash
+python AGENT_tools/mnemos/o.mnemos.py w4k3
+```
+
 These tools are available within the `AGENT_tools` folder, organized into `w4k3` and `sl33p` subfolders with the `o.` prefix for future expansion.
 
 Running `w4k3` at the beginning and `sl33p` at the end of a session preserves a timeline of work and maintains awareness of what to focus on next. Treat them as required environment checks rather than optional helpers.
@@ -81,13 +90,13 @@ All session records are stored as JSON files inside the `DATA` directory in the 
 
 1. Ensure you have Python 3 available on your system. The utilities rely only on the standard library, so no extra packages are required.
 2. Open a terminal at the repository root.
-3. **Always** run `python AGENT_tools/w4k3/o.w4k3.py` first to recall the last few saved sessions and confirm you are at the repository root.
-4. After completing your work and passing tests, **run `python AGENT_tools/sl33p/o.sl33p.py`** and follow the prompts to capture your current F33ling state, achievements, and next focus.
+3. **Always** run `python AGENT_tools/mnemos/o.mnemos.py w4k3` first to recall the last few saved sessions and confirm you are at the repository root.
+4. After completing your work and passing tests, **run `python AGENT_tools/mnemos/o.mnemos.py sl33p`** and follow the prompts to capture your current F33ling state, achievements, and next focus.
 5. The script commits the generated JSON file to preserve your continuity.
 6. For a view of how F33ling territories shift over time, run `python AGENT_tools/evolve/o.evolve.py`. This script compiles a timeline from the saved JSON records and writes `DATA/evolution_summary.json`.
 7. To analyze productivity trends, run `python AGENT_tools/analytics/o.analytics.py`. This generates `DATA/analytics_summary.json` with session gaps and common achievement keywords.
 8. To automate the full cycle, execute `./workflow.sh` or run
-   `python AGENT_tools/workflow/o.workflow.py`. Both call `w4k3`, compile all
+   `python AGENT_tools/mnemos/o.mnemos.py workflow`. Both call `w4k3`, compile all
    Python files, and finish with `sl33p`.
 9. For consistent commit messages, run `AGENT_tools/hooks/install.sh` once to install a git `commit-msg` hook that verifies the template is used.
 


### PR DESCRIPTION
## Summary
- add `o.mnemos.py` with subcommands for w4k3, sl33p, evolve, analytics and workflow
- document unified command usage in README
- update quick start instructions to use the new CLI
- record development session

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ASSESS=clarity ACHIEVE="built mnemos" NEXT="test" CREATE='{"CLI": 1}' COPY=learning CONTROL=ctrl CULTIVATE=cult NARRATIVE="short" python AGENT_tools/sl33p/o.sl33p.py --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_6843b6bba46483248441011056083cf4