### PR TITLE
Fix sl33p prompt bug

### DIFF
--- a/AGENT_tools/sl33p/o.sl33p.py
+++ b/AGENT_tools/sl33p/o.sl33p.py
@@ -199,6 +199,7 @@ def main():
             copy_i,
             control_i,
             cultivate_i,
+            narrative_i,
         ) = prompt_user()
         assessment = assessment or assessment_i
         achievements = achievements or achievements_i

--- a/DATA/20250607T123618Z_v2.json
+++ b/DATA/20250607T123618Z_v2.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "20250607T123618Z_v2",
+  "assessment": "clarity",
+  "achievements": "fixed sl33p prompt bug",
+  "next": "review CLI",
+  "aspects": {
+    "bugfix": 1
+  },
+  "learning": "source",
+  "methodology": "workflow",
+  "framework_depth": "documentation",
+  "narrative": "Fixed unpacking error in sl33p interactive prompts",
+  "tetra": {
+    "create": {
+      "bugfix": 1
+    },
+    "copy": "source",
+    "control": "workflow",
+    "cultivate": "documentation"
+  }
+}


### PR DESCRIPTION
## Summary
- record session data
- fix argument unpacking for `sl33p` interactive prompts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684431bc4b048324bd362124fc80e018