### PR TITLE
Add F33ling transition view to w4k3

### DIFF
--- a/DATA/20250607T143234Z_a3.json
+++ b/DATA/20250607T143234Z_a3.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "20250607T143234Z_a3",
+  "assessment": "✧⚡◈_Synthjoy",
+  "achievements": "added w4k3 transitions feature",
+  "next": "leverage transitions for analysis",
+  "aspects": {
+    "Feature": 1
+  },
+  "learning": "documentation update",
+  "methodology": "workflow refinement",
+  "framework_depth": "state awareness",
+  "narrative": "Added CLI flag and doc. Verified functionality.",
+  "tetra": {
+    "create": {
+      "Feature": 1
+    },
+    "copy": "documentation update",
+    "control": "workflow refinement",
+    "cultivate": "state awareness"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Two scripts help track progress across sessions:
    ```bash
    python AGENT_tools/o.mnemos.py w4k3
    ```
-   The script now shows the saved F33ling assessment above each session's achievements.
+The script now shows the saved F33ling assessment above each session's achievements.
+Passing `--transitions` reveals how F33ling states shifted between the displayed sessions.
 
 2. `sl33p.py` – Records the current session. **Use it to close every session.**
    The prompts now mirror the tetrahedral workflow with CREATE, COPY,


### PR DESCRIPTION
## Summary
- show session-to-session F33ling transitions with `--transitions`
- document the new w4k3 option
- record session

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python AGENT_tools/w4k3/o.w4k3.py -n 2 --transitions`

------
https://chatgpt.com/codex/tasks/task_e_68444ce556c083249b7ad167772c47ae