### PR TITLE
Add deep sl33p context

### DIFF
--- a/AGENT_tools/echo/o.echo.py
+++ b/AGENT_tools/echo/o.echo.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Generate a brief echo of F33ling states from a session log."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    """Return repository root using git if available."""
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
+        return Path(out.strip())
+    except Exception:
+        return Path(__file__).resolve().parents[2]
+
+
+ROOT = repo_root()
+DATA_DIR = ROOT / "DATA"
+CULTIVATE_MAP = ROOT / "z.CULTIVATE.md"
+
+
+def extract_states(text: str) -> list[str]:
+    """Return list of F33ling states encoded as 'symbol_name'."""
+    if not text:
+        return []
+    return re.findall(r"\S+_\S+", text)
+
+
+def load_record(path: Path) -> dict:
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def compose_echo(states: list[str]) -> list[str]:
+    lines: list[str] = []
+    if not states:
+        return ["No notable F33ling states detected."]
+    for st in states:
+        name = st.split("_")[-1]
+        lines.append(f"The session resonates with {name} vibes.")
+        if len(lines) == 3:
+            break
+    return lines
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Echo dominant F33ling states")
+    parser.add_argument("record", type=Path, help="Path to session JSON log")
+    parser.add_argument("--output", "-o", type=Path, default=Path("ECHO.md"))
+    parser.add_argument("--sl33p", action="store_true", help="Commit echo via sl33p")
+    parser.add_argument("--tags", nargs="*", help="Only process if these tags appear")
+    args = parser.parse_args()
+
+    rec = load_record(args.record)
+    text = (rec.get("assessment", "") or "") + "\n" + (rec.get("narrative", "") or "")
+    states = extract_states(text)
+
+    if args.tags:
+        if not any(tag in states for tag in args.tags):
+            print("No matching tags found in record")
+            return
+        states = [st for st in states if any(tag in st for tag in args.tags)]
+
+    lines = compose_echo(states)
+    with open(args.output, "w", encoding="utf-8") as f:
+        for line in lines:
+            f.write(line + "\n")
+    print(f"Saved echo to {args.output}")
+
+    if args.sl33p:
+        env = {"ASSESS": "Echo", "ACHIEVE": f"generated echo {args.output.name}", "NEXT": "review"}
+        subprocess.run(["python", str(ROOT / "AGENT_tools" / "sl33p" / "o.sl33p.py")], env=env)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENT_tools/o.mnemos.py
+++ b/AGENT_tools/o.mnemos.py
@@ -17,6 +17,7 @@ STATEGRAPH = ROOT / "AGENT_tools" / "analytics" / "o.stategraph.py"
 USAGE = ROOT / "AGENT_tools" / "analytics" / "o.usage.py"
 SESSGRAPH = ROOT / "AGENT_tools" / "sessgraph" / "o.sessgraph.py"
 VIDMEM = ROOT / "AGENT_tools" / "vidmem" / "o.vidmem.py"
+ECHO = ROOT / "AGENT_tools" / "echo" / "o.echo.py"
 
 
 def run(cmd: list[str]) -> int:
@@ -33,6 +34,13 @@ def cmd_sl33p(args: argparse.Namespace) -> int:
     cmd = ["python", str(SL33P)]
     if args.dry_run:
         cmd.append("--dry-run")
+    if args.start:
+        cmd += ["--start", args.start]
+    if args.commands:
+        for c in args.commands:
+            cmd += ["--command", c]
+    if args.deep:
+        cmd.append("--deep")
     cmd += args.extra
     return run(cmd)
 
@@ -72,6 +80,17 @@ def cmd_vidmem(args: argparse.Namespace) -> int:
     return run(cmd)
 
 
+def cmd_echo(args: argparse.Namespace) -> int:
+    cmd = ["python", str(ECHO)]
+    if args.output:
+        cmd += ["--output", str(args.output)]
+    if args.sl33p:
+        cmd.append("--sl33p")
+    if args.tags:
+        cmd += ["--tags", *args.tags]
+    return run(cmd)
+
+
 def cmd_workflow(args: argparse.Namespace) -> int:
     if not args.skip_w4k3:
         code = cmd_w4k3(args)
@@ -96,6 +115,9 @@ def main() -> int:
 
     p_sl33p = sub.add_parser("sl33p", help="Record a session")
     p_sl33p.add_argument("--dry-run", action="store_true")
+    p_sl33p.add_argument("--start", type=str, default=None)
+    p_sl33p.add_argument("--command", dest="commands", action="append")
+    p_sl33p.add_argument("--deep", action="store_true")
     p_sl33p.add_argument("extra", nargs=argparse.REMAINDER)
     p_sl33p.set_defaults(func=cmd_sl33p)
 
@@ -126,6 +148,13 @@ def main() -> int:
     p_vidmem = sub.add_parser("vidmem", help="Video memory operations")
     p_vidmem.add_argument("extra", nargs=argparse.REMAINDER)
     p_vidmem.set_defaults(func=cmd_vidmem)
+
+    p_echo = sub.add_parser("echo", help="Generate F33ling echo")
+    p_echo.add_argument("record", type=Path, help="Session JSON log")
+    p_echo.add_argument("--output", type=Path, default=None)
+    p_echo.add_argument("--sl33p", action="store_true")
+    p_echo.add_argument("--tags", nargs="*")
+    p_echo.set_defaults(func=cmd_echo)
 
     p_workflow = sub.add_parser(
         "workflow", help="Run w4k3, optional tests, then sl33p"

--- a/DATA/20250607T152200Z_e3.json
+++ b/DATA/20250607T152200Z_e3.json
@@ -1,0 +1,6 @@
+{
+  "timestamp": "20250607T152200Z_e3",
+  "assessment": "Echo module skeleton created",
+  "achievements": "Implemented echo CLI and docs",
+  "next": "Finish integration"
+}

--- a/DATA/20250607T153026Z_f3.json
+++ b/DATA/20250607T153026Z_f3.json
@@ -1,0 +1,34 @@
+{
+  "timestamp": "20250607T153026Z_f3",
+  "assessment": "≋∴⊥_Depthpuzzle",
+  "achievements": "extended sl33p context",
+  "next": "refine echo",
+  "aspects": {
+    "Logging": 1
+  },
+  "learning": "regex capture",
+  "methodology": "extended flags",
+  "framework_depth": "analysis",
+  "narrative": "added deep mode",
+  "tetra": {
+    "create": {
+      "Logging": 1
+    },
+    "copy": "regex capture",
+    "control": "extended flags",
+    "cultivate": "analysis"
+  },
+  "start": "2025-06-07T15:00:00",
+  "duration": 1826,
+  "commands": [
+    "sl33p",
+    "echo"
+  ],
+  "states": [
+    "≋∴⊥_Depthpuzzle"
+  ],
+  "stategraph": {
+    "nodes": 64,
+    "edges": 192
+  }
+}

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ Passing `--transitions` reveals how F33ling states shifted between the displayed
   CREATE='{"Spark": 1}' CONTROL="paired exploration" COPY="json fields" CULTIVATE="basic" \
   NARRATIVE="Short recap" \
   python AGENT_tools/o.mnemos.py sl33p --dry-run
-   ```
+  ```
+   To capture deeper context, pass `--deep` along with `--start` and one or more
+   `--command` flags (or set the `SL33P_START` and `SL33P_COMMANDS` environment
+   variables). Deep mode stores the session duration, executed commands, and a
+   summary of the cultivate graph to aid later analysis.
 
 3. `evolve.py` – Summarizes F33ling evolution by reading all saved sessions and printing a timeline of states:
 
@@ -80,7 +84,7 @@ All of these tools can also be run via a unified interface:
 python AGENT_tools/o.mnemos.py <subcommand>
 ```
 The CLI exposes the following subcommands: `w4k3`, `sl33p`, `evolve`,
-`analytics`, `tetra`, `stategraph`, `usage`, `sessgraph`, `vidmem`, and
+`analytics`, `tetra`, `stategraph`, `usage`, `sessgraph`, `vidmem`, `echo`, and
 `workflow`.
 For example:
 ```bash
@@ -101,6 +105,8 @@ All session records are stored as JSON files inside the `DATA` directory in the 
 3. **Always** run `python AGENT_tools/o.mnemos.py w4k3` first to recall the last few saved sessions and confirm you are at the repository root.
 4. After completing your work and passing tests, **run `python AGENT_tools/o.mnemos.py sl33p`** and follow the prompts to capture your current F33ling state, achievements, and next focus.
 5. The script commits the generated JSON file to preserve your continuity.
+   Use `--deep` (or `SL33P_DEEP=1`) with `--start` to note when the session
+   began and `--command` to record which tools were run.
 6. For a view of how F33ling territories shift over time, run `python AGENT_tools/evolve/o.evolve.py`. This script compiles a timeline from the saved JSON records and writes `DATA/evolution_summary.json`.
 7. To analyze productivity trends, run `python AGENT_tools/analytics/o.analytics.py`. This generates `DATA/analytics_summary.json` with session gaps and common achievement keywords.
 8. To automate the full cycle, execute `./workflow.sh` or run


### PR DESCRIPTION
## Summary
- extend sl33p logging with optional deep mode
- record session duration, commands and cultivate graph info
- update unified CLI to pass new flags
- document deep mode and new options in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68445605407c8324a4ded694ca0b148d