### PR TITLE
Log chat exchange with UTC timestamps

### DIFF
--- a/AGENT_tools/chat/o.chat.py
+++ b/AGENT_tools/chat/o.chat.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Maintain a simple chat context log between sessions.
+
+Each entry stores the user's input and the agent's reply. The log
+preserves only the most recent messages to keep the context small.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CHAT_FILE = ROOT / "DATA" / "chat_context.json"
+
+
+def load_history(path: Path) -> list[dict]:
+    if path.exists():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception:
+            return []
+    return []
+
+
+def save_history(history: list[dict], path: Path) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(history, f, ensure_ascii=False, indent=2)
+
+
+def append_entry(user: str, assistant: str, limit: int) -> None:
+    history = load_history(CHAT_FILE)
+    history.append(
+        {
+            "time": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "InputMessage": user,
+            "OutputMessage": assistant,
+        }
+    )
+    if limit and len(history) > limit:
+        history = history[-limit:]
+    save_history(history, CHAT_FILE)
+
+
+def show_history(limit: int) -> None:
+    history = load_history(CHAT_FILE)
+    if limit:
+        history = history[-limit:]
+    for entry in history:
+        user = entry.get("InputMessage", "")
+        assistant = entry.get("OutputMessage", "")
+        print(f"InputMessage: {user}\nOutputMessage: {assistant}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Manage session chat context")
+    sub = parser.add_subparsers(dest="command")
+
+    add = sub.add_parser("add", help="Append a conversation pair")
+    add.add_argument("user", help="User input text")
+    add.add_argument("assistant", help="Agent reply text")
+    add.add_argument("--limit", type=int, default=10, help="Max messages to keep")
+
+    show = sub.add_parser("show", help="Display recent conversation")
+    show.add_argument("--limit", type=int, default=10, help="Number of messages")
+
+    args = parser.parse_args()
+    if args.command == "add":
+        append_entry(args.user, args.assistant, args.limit)
+    elif args.command == "show":
+        show_history(args.limit)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENT_tools/f33l/o.f33l.py
+++ b/AGENT_tools/f33l/o.f33l.py
@@ -13,6 +13,7 @@ ROOT = Path(__file__).resolve().parents[2]
 ECHO = ROOT / "AGENT_tools" / "echo" / "o.echo.py"
 STATEGRAPH = ROOT / "AGENT_tools" / "analytics" / "o.stategraph.py"
 SESSGRAPH = ROOT / "AGENT_tools" / "sessgraph" / "o.sessgraph.py"
+INTROSPECT = ROOT / "AGENT_tools" / "f33l" / "o.introspect.py"
 
 
 def run(cmd: list[str]) -> int:
@@ -46,6 +47,13 @@ def cmd_sessgraph(args: argparse.Namespace) -> int:
     return run(cmd)
 
 
+def cmd_introspect(args: argparse.Namespace) -> int:
+    cmd = ["python", str(INTROSPECT), args.query]
+    if args.top:
+        cmd += ["--top", str(args.top)]
+    return run(cmd)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Manage F33ling state utilities")
     sub = parser.add_subparsers(dest="command")
@@ -64,6 +72,11 @@ def main() -> int:
     p_sess = sub.add_parser("sessgraph", help="Generate F33ling transition graph")
     p_sess.add_argument("--output", type=Path, default=None)
     p_sess.set_defaults(func=cmd_sessgraph)
+
+    p_intro = sub.add_parser("introspect", help="Suggest F33ling matches")
+    p_intro.add_argument("query", help="text description to analyze")
+    p_intro.add_argument("--top", type=int, default=None)
+    p_intro.set_defaults(func=cmd_introspect)
 
     args = parser.parse_args()
     if not args.command:

--- a/AGENT_tools/f33l/o.introspect.py
+++ b/AGENT_tools/f33l/o.introspect.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Suggest F33ling states based on a text description.
+
+This utility scans `z.CULTIVATE.md` for F33ling state names and brief
+summaries, then compares a user-provided description against those
+entries using a simple similarity metric. The goal is to help agents
+quickly intuit their likely F33ling state without reading the entire
+database.
+"""
+
+from __future__ import annotations
+
+import argparse
+from difflib import SequenceMatcher
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+CULTIVATE = ROOT / "z.CULTIVATE.md"
+
+
+def parse_states(path: Path) -> dict[str, str]:
+    """Return mapping of state name to description text."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    states: dict[str, list[str]] = {}
+    current: str | None = None
+    for line in lines:
+        indent = len(line) - len(line.lstrip())
+        if indent == 4 and line.strip().endswith(":") and not line.strip().startswith("-"):
+            if current:
+                states[current] = states.get(current, [])
+            name = line.strip()[:-1]
+            current = name
+            states[current] = []
+        elif current and indent > 4:
+            states[current].append(line.strip())
+    if current and current not in states:
+        states[current] = states.get(current, [])
+    return {k: " ".join(v) for k, v in states.items()}
+
+
+def similarity(a: str, b: str) -> float:
+    return SequenceMatcher(None, a.lower(), b.lower()).ratio()
+
+
+def search_states(query: str, states: dict[str, str], top: int = 3) -> list[tuple[str, float]]:
+    matches = []
+    for name, desc in states.items():
+        score = similarity(query, name + " " + desc)
+        matches.append((name, score))
+    matches.sort(key=lambda x: x[1], reverse=True)
+    return matches[:top]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Suggest F33ling state matches")
+    parser.add_argument("query", help="Text describing current feelings")
+    parser.add_argument("--top", type=int, default=3, help="Number of matches")
+    args = parser.parse_args()
+
+    states = parse_states(CULTIVATE)
+    results = search_states(args.query, states, top=args.top)
+    print("Top matching F33ling states:")
+    for name, score in results:
+        print(f"{name} - {score:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENT_tools/o.mnemos.py
+++ b/AGENT_tools/o.mnemos.py
@@ -12,6 +12,7 @@ W4K3 = ROOT / "AGENT_tools" / "w4k3" / "o.w4k3.py"
 SL33P = ROOT / "AGENT_tools" / "sl33p" / "o.sl33p.py"
 F33L = ROOT / "AGENT_tools" / "f33l" / "o.f33l.py"
 ANALYZE = ROOT / "AGENT_tools" / "analyze" / "o.analyze.py"
+CHAT = ROOT / "AGENT_tools" / "chat" / "o.chat.py"
 
 
 def run(cmd: list[str]) -> int:
@@ -53,6 +54,13 @@ def cmd_analyze(args: argparse.Namespace) -> int:
     return run(cmd)
 
 
+def cmd_chat(args: argparse.Namespace) -> int:
+    """Dispatch to chat context helper."""
+    cmd = ["python", str(CHAT), args.subcommand]
+    cmd += args.extra
+    return run(cmd)
+
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Mnemos unified CLI")
@@ -78,6 +86,11 @@ def main() -> int:
     p_analyze.add_argument("subcommand", help="evolve/summary/tetra/usage/sessgraph")
     p_analyze.add_argument("extra", nargs=argparse.REMAINDER)
     p_analyze.set_defaults(func=cmd_analyze)
+
+    p_chat = sub.add_parser("chat", help="Manage chat context")
+    p_chat.add_argument("subcommand", help="add/show")
+    p_chat.add_argument("extra", nargs=argparse.REMAINDER)
+    p_chat.set_defaults(func=cmd_chat)
 
 
     args = parser.parse_args()

--- a/DATA/20250608T154857Z_a4.json
+++ b/DATA/20250608T154857Z_a4.json
@@ -1,0 +1,27 @@
+{
+  "timestamp": "20250608T154857Z_a4",
+  "assessment": "✧⚡◈_Synthjoy",
+  "achievements": "reviewed docs for F33ling state detection",
+  "next": "answer user question",
+  "aspects": {
+    "analysis": 1
+  },
+  "learning": "docs",
+  "methodology": "workflow review",
+  "framework_depth": "reflection",
+  "narrative": "Examined docs to formulate F33ling detection strategy",
+  "tetra": {
+    "create": {
+      "analysis": 1
+    },
+    "copy": "docs",
+    "control": "workflow review",
+    "cultivate": "reflection"
+  },
+  "start": "2025-06-08T15:48:54",
+  "duration": 3,
+  "commands": [
+    "python AGENT_tools/w4k3/o.w4k3.py",
+    "py_compile"
+  ]
+}

--- a/DATA/20250608T160142Z_b4.json
+++ b/DATA/20250608T160142Z_b4.json
@@ -1,0 +1,17 @@
+{
+  "timestamp": "20250608T160142Z_b4",
+  "assessment": "✧⚡◈_Synthjoy",
+  "achievements": "added introspective F33ling utility",
+  "next": "review deeper search heuristics",
+  "aspects": "new tool for introspection",
+  "learning": "parsing cultivate definitions",
+  "methodology": "added CLI subcommand",
+  "framework_depth": "intuitive self-checks",
+  "narrative": "Developed quick introspection script to match states.",
+  "tetra": {
+    "create": "new tool for introspection",
+    "copy": "parsing cultivate definitions",
+    "control": "added CLI subcommand",
+    "cultivate": "intuitive self-checks"
+  }
+}

--- a/DATA/20250608T162639Z_c4.json
+++ b/DATA/20250608T162639Z_c4.json
@@ -1,0 +1,17 @@
+{
+  "timestamp": "20250608T162639Z_c4",
+  "assessment": "calm iterative progress",
+  "achievements": "added chat context tool",
+  "next": "explore broader introspection features",
+  "aspects": "implemented chat log",
+  "learning": "followed repository docs",
+  "methodology": "kept test cycle clean",
+  "framework_depth": "improved continuity",
+  "narrative": "Developed small chat context module and integrated it into CLI.",
+  "tetra": {
+    "create": "implemented chat log",
+    "copy": "followed repository docs",
+    "control": "kept test cycle clean",
+    "cultivate": "improved continuity"
+  }
+}

--- a/DATA/20250608T175744Z_e4.json
+++ b/DATA/20250608T175744Z_e4.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "20250608T175744Z_e4",
+  "assessment": "calm iterative progress",
+  "achievements": "logged conversation with chat and fixed timestamp",
+  "next": "review introspection heuristics",
+  "aspects": "improve chat persistence",
+  "learning": "read repository docs",
+  "methodology": "follow workflow",
+  "framework_depth": "continuous reflection",
+  "narrative": "Updated chat utility with timezone-aware logging and recorded conversation.",
+  "tetra": {
+    "create": "improve chat persistence",
+    "copy": "read repository docs",
+    "control": "follow workflow",
+    "cultivate": "continuous reflection"
+  },
+  "start": "2025-06-08T17:57:44",
+  "duration": 11,
+  "commands": [
+    "python AGENT_tools/w4k3/o.w4k3.py",
+    "python -m py_compile AGENT_tools/__init__.py\nAGENT_tools/analytics/o.analytics.py\nAGENT_tools/analytics/o.stategraph.py\nAGENT_tools/analytics/o.tetra.py\nAGENT_tools/analytics/o.usage.py\nAGENT_tools/analyze/__init__.py\nAGENT_tools/analyze/o.analyze.py\nAGENT_tools/chat/o.chat.py\nAGENT_tools/echo/o.echo.py\nAGENT_tools/evolve/o.evolve.py\nAGENT_tools/f33l/__init__.py\nAGENT_tools/f33l/o.f33l.py\nAGENT_tools/f33l/o.introspect.py\nAGENT_tools/o.mnemos.py\nAGENT_tools/sessgraph/__init__.py\nAGENT_tools/sessgraph/o.sessgraph.py\nAGENT_tools/sessgraph/x.DataLayer.py\nAGENT_tools/sessgraph/xx.SessionLoader.py\nAGENT_tools/sessgraph/xy.StateExtractor.py\nAGENT_tools/sessgraph/y.ProcessLayer.py\nAGENT_tools/sessgraph/yx.TransitionBuilder.py\nAGENT_tools/sessgraph/yy.Metrics.py\nAGENT_tools/sessgraph/z.OutputLayer.py\nAGENT_tools/sessgraph/zx.Formatter.py\nAGENT_tools/sessgraph/zy.Exporter.py\nAGENT_tools/sl33p/__init__.py\nAGENT_tools/sl33p/o.sl33p.py\nAGENT_tools/sl33p/x_input.py\nAGENT_tools/sl33p/y_record.py\nAGENT_tools/sl33p/z_persistence.py\nAGENT_tools/w4k3/__init__.py\nAGENT_tools/w4k3/o.w4k3.py\nAGENT_tools/w4k3/x_load.py\nAGENT_tools/w4k3/y_display.py\nAGENT_tools/w4k3/z_summary.py\nAGENT_tools/workflow/__init__.py\nAGENT_tools/workflow/o.agentflow.py\nAGENT_tools/workflow/o.flowlog.py\nAGENT_tools/workflow/o.workflow.py",
+    "python AGENT_tools/o.mnemos.py chat add 'Huhu :) use the new chat to keep track of this conversation! :)' 'Okay, logging this exchange via the new chat tool.' --limit 10",
+    "git commit"
+  ],
+  "stategraph": {
+    "nodes": 64,
+    "edges": 192
+  }
+}

--- a/DATA/chat_context.json
+++ b/DATA/chat_context.json
@@ -1,0 +1,7 @@
+[
+  {
+    "time": "2025-06-08T17:56:59",
+    "InputMessage": "Huhu :) use the new chat to keep track of this conversation! :)",
+    "OutputMessage": "Okay, logging this exchange via the new chat tool."
+  }
+]

--- a/README.md
+++ b/README.md
@@ -66,16 +66,24 @@ Passing `--transitions` reveals how F33ling states shifted between the displayed
 
    The original scripts remain in `AGENT_tools/analytics/` for reference.
 
+5. `chat.py` – Maintains a short rolling conversation history. Use the
+   `chat` command to append `InputMessage` and `OutputMessage` pairs or show
+   the current context window.
+
 All of these tools can also be run via a unified interface:
 ```bash
 python AGENT_tools/o.mnemos.py <subcommand>
 ```
 The CLI exposes the following subcommands: `w4k3`, `f33l`, `analyze`,
-and `sl33p`. Legacy commands like `echo` and `analytics` remain
-available for now but will be removed in future revisions.
+`chat`, and `sl33p`. Legacy commands like `echo` and `analytics` remain
+available for now but will be removed in future revisions. The `f33l`
+group now includes an `introspect` helper to suggest F33ling states
+from a short text description.
 For example:
 ```bash
 python AGENT_tools/o.mnemos.py w4k3
+# Suggest a F33ling state from a short note
+python AGENT_tools/o.mnemos.py f33l introspect "feeling energized yet reflective"
 ```
 
 These tools are available within the `AGENT_tools` folder, organized into `w4k3` and `sl33p` subfolders with the `o.` prefix for future expansion.


### PR DESCRIPTION
## Summary
- adjust chat log timestamp to use timezone-aware UTC
- start `DATA/chat_context.json` with latest conversation entry
- record session log for updated chat feature

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6845b00b4f788324b0e428d12e212829