### PR TITLE
Test chat context logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,9 @@ This repository maintains the agent-network optimization framework **Mnemos** us
 
 1. **Load context with `w4k3` (mandatory)**
 
+   The `w4k3` command now prints the last few chat messages before showing
+   recent session logs so every agent sees the current conversation first.
+
    ```bash
    python AGENT_tools/w4k3/o.w4k3.py
    ```
@@ -34,6 +37,13 @@ This repository maintains the agent-network optimization framework **Mnemos** us
    ```
 Deep mode is enabled by default so each record includes the start time, executed commands, and a cultivate graph summary. Pass `--no-deep` only if minimal logging is required.
 Use this script at the end of every session. It asks for a brief state assessment, your achievements, and next priorities, then commits the result to `DATA/`. Skipping this step breaks the continuity chain for other agents. Even sessions devoted solely to reading or exploration must be logged so future contributors know what was examined and why.
+
+   The script now also records the latest user message and agent reply to
+   `DATA/chat_context.json`. Provide them via the `--chat-in` and
+   `--chat-out` options (or the `CHAT_IN` and `CHAT_OUT` environment
+   variables) when running `sl33p`. If omitted, you will be prompted.
+   Logging this conversation snippet is mandatory so `w4k3` can show the
+   ongoing discussion at the next session start.
 
 Following this loop keeps the development archaeology clear and lets each CODEX agent build on the last session. Omitting `w4k3` or `sl33p` risks corrupting the shared timeline.
 

--- a/AGENT_tools/chat/__init__.py
+++ b/AGENT_tools/chat/__init__.py
@@ -1,0 +1,15 @@
+"""Import helpers for chat context."""
+
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+FILE = Path(__file__).with_name('o.chat.py')
+loader = SourceFileLoader('ochat', str(FILE))
+spec = spec_from_loader('ochat', loader)
+module = module_from_spec(spec)
+loader.exec_module(module)
+
+append_entry = module.append_entry
+show_history = module.show_history
+CHAT_FILE = module.CHAT_FILE

--- a/AGENT_tools/sl33p/o.sl33p.py
+++ b/AGENT_tools/sl33p/o.sl33p.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from AGENT_tools.sl33p.z_persistence import (
     parse_cultivate,
     repo_root,
 )
+from AGENT_tools.chat import append_entry, CHAT_FILE
 
 
 def main() -> None:
@@ -35,6 +37,9 @@ def main() -> None:
     parser.add_argument("--start", type=str, default=None, help="ISO start time for duration")
     parser.add_argument("--command", dest="commands", action="append", help="Command run during session")
     parser.add_argument("--no-deep", action="store_true", help="Disable deep context logging")
+    parser.add_argument("--chat-in", type=str, default=None, help="User message to log")
+    parser.add_argument("--chat-out", type=str, default=None, help="Assistant reply to log")
+    parser.add_argument("--chat-limit", type=int, default=int(os.getenv("CHAT_LIMIT", 10)), help="Max chat messages to keep")
     args = parser.parse_args()
 
     ensure_data_dir()
@@ -51,6 +56,10 @@ def main() -> None:
     control = os.getenv("CONTROL") or os.getenv("METHOD") or os.getenv("OPTIM")
     cultivate = os.getenv("CULTIVATE") or os.getenv("DEPTH")
     optimization = os.getenv("OPTIM")
+
+    chat_in = args.chat_in or os.getenv("CHAT_IN")
+    chat_out = args.chat_out or os.getenv("CHAT_OUT")
+    chat_limit = args.chat_limit
 
     if not all([
         assessment,
@@ -81,6 +90,11 @@ def main() -> None:
         cultivate = cultivate or cultivate_i
         narrative = narrative or narrative_i
 
+    if chat_in is None:
+        chat_in = input("InputMessage to log: ")
+    if chat_out is None:
+        chat_out = input("OutputMessage to log: ")
+
     assessment = sanitize(assessment)
     achievements = sanitize(achievements)
     next_steps = sanitize(next_steps)
@@ -90,6 +104,8 @@ def main() -> None:
     cultivate_val = sanitize(cultivate) if cultivate else None
     narrative_val = sanitize(narrative) if narrative else None
     optimization_val = sanitize(optimization) if optimization else None
+    chat_in_val = sanitize(chat_in) if chat_in else ""
+    chat_out_val = sanitize(chat_out) if chat_out else ""
 
     dry = args.dry_run or os.getenv("SL33P_DRY_RUN")
 
@@ -141,8 +157,15 @@ def main() -> None:
     if save_record(record, dry_run=dry, timestamp=ts):
         if dry:
             print(f"Dry run complete for {ts}.json")
+            print(f"Chat: {chat_in_val} -> {chat_out_val}")
         else:
             print(f"Session recorded as {ts}.json")
+            append_entry(chat_in_val, chat_out_val, chat_limit)
+            try:
+                subprocess.run(["git", "add", str(CHAT_FILE)], check=True)
+                subprocess.run(["git", "commit", "-m", "Update chat context"], check=True)
+            except Exception as e:
+                print(f"Failed to commit chat log: {e}")
 
 
 if __name__ == "__main__":

--- a/AGENT_tools/w4k3/x_load.py
+++ b/AGENT_tools/w4k3/x_load.py
@@ -43,7 +43,7 @@ def load_records(limit: int) -> list[dict]:
         print("DATA directory not found. No previous sessions recorded.")
         return []
 
-    files = list(ddir.glob("*.json"))
+    files = [f for f in ddir.glob("*.json") if f.name != "chat_context.json"]
     recs_with_time = []
     for file in files:
         try:

--- a/AGENT_tools/w4k3/y_display.py
+++ b/AGENT_tools/w4k3/y_display.py
@@ -17,6 +17,28 @@ def extract_states(text: str) -> list[str]:
     return re.findall(r"\S+_\S+", text)
 
 
+def display_chat(limit: int = 3) -> None:
+    """Show recent chat messages."""
+    path = data_dir() / "chat_context.json"
+    if not path.exists():
+        return
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            history = json.load(f)
+    except Exception:
+        return
+    if limit:
+        history = history[-limit:]
+    if not history:
+        return
+    print("Chat context:")
+    for entry in history:
+        user = entry.get("InputMessage", "")
+        assistant = entry.get("OutputMessage", "")
+        print(f"InputMessage: {user}\nOutputMessage: {assistant}\n")
+    print()
+
+
 def display(records: list[dict]) -> None:
     """Print a summary of each record."""
     if not records:
@@ -92,6 +114,8 @@ def summarize_all() -> None:
     counts = {"create": 0, "copy": 0, "control": 0, "cultivate": 0}
     total = 0
     for path in ddir.glob("*.json"):
+        if path.name == "chat_context.json":
+            continue
         try:
             with open(path, "r", encoding="utf-8") as f:
                 rec = json.load(f)

--- a/AGENT_tools/w4k3/z_summary.py
+++ b/AGENT_tools/w4k3/z_summary.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import argparse
 
 from AGENT_tools.w4k3.x_load import load_records
-from AGENT_tools.w4k3.y_display import display, display_transitions, summarize_all
+from AGENT_tools.w4k3.y_display import (
+    display,
+    display_transitions,
+    summarize_all,
+    display_chat,
+)
 
 
 def main() -> None:
@@ -23,8 +28,15 @@ def main() -> None:
         action="store_true",
         help="Show F33ling transitions between sessions",
     )
+    parser.add_argument(
+        "--chat-limit",
+        type=int,
+        default=3,
+        help="Number of chat messages to display first",
+    )
     args = parser.parse_args()
 
+    display_chat(args.chat_limit)
     records = load_records(args.limit)
     display(records)
     if args.transitions:

--- a/DATA/20250608T202359Z_f4.json
+++ b/DATA/20250608T202359Z_f4.json
@@ -1,0 +1,24 @@
+{
+  "timestamp": "20250608T202359Z_f4",
+  "assessment": "calm iterative progress",
+  "achievements": "added chat display to w4k3",
+  "next": "none",
+  "aspects": "chat displayed",
+  "learning": "w4k3 update",
+  "methodology": "skip",
+  "framework_depth": "skip",
+  "narrative": "implemented chat context",
+  "tetra": {
+    "create": "chat displayed",
+    "copy": "w4k3 update",
+    "control": "skip",
+    "cultivate": "skip"
+  },
+  "commands": [
+    "python AGENT_tools/w4k3/o.w4k3.py"
+  ],
+  "stategraph": {
+    "nodes": 64,
+    "edges": 192
+  }
+}

--- a/DATA/20250609T003612Z_g4.json
+++ b/DATA/20250609T003612Z_g4.json
@@ -1,0 +1,21 @@
+{
+  "timestamp": "20250609T003612Z_g4",
+  "assessment": "testing",
+  "achievements": "ran chat tests",
+  "next": "none",
+  "aspects": "test",
+  "learning": "test",
+  "methodology": "test",
+  "framework_depth": "test",
+  "narrative": "tested chat integration",
+  "tetra": {
+    "create": "test",
+    "copy": "test",
+    "control": "test",
+    "cultivate": "test"
+  },
+  "stategraph": {
+    "nodes": 64,
+    "edges": 192
+  }
+}

--- a/DATA/chat_context.json
+++ b/DATA/chat_context.json
@@ -3,5 +3,10 @@
     "time": "2025-06-08T17:56:59",
     "InputMessage": "Huhu :) use the new chat to keep track of this conversation! :)",
     "OutputMessage": "Okay, logging this exchange via the new chat tool."
+  },
+  {
+    "time": "2025-06-09T00:36:12+00:00",
+    "InputMessage": "Integration test message",
+    "OutputMessage": "Integration test reply"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Passing `--transitions` reveals how F33ling states shifted between the displayed
 
 5. `chat.py` – Maintains a short rolling conversation history. Use the
    `chat` command to append `InputMessage` and `OutputMessage` pairs or show
-   the current context window.
+   the current context window. `sl33p` automatically logs the last pair so
+   future sessions open with the recent conversation.
 
 All of these tools can also be run via a unified interface:
 ```bash
@@ -107,7 +108,11 @@ All session records are stored as JSON files inside the `DATA` directory in the 
    ```
 
 
-6. The script commits the generated JSON file to preserve your continuity. Aim to populate all fields—including the narrative—to keep an authentic diary of exploration.
+6. The script commits the generated JSON file to preserve your continuity and
+   now also appends the latest conversation pair to `DATA/chat_context.json`.
+   Provide the messages via `CHAT_IN` and `CHAT_OUT` or the `--chat-in` and
+   `--chat-out` options when running `sl33p`. If not supplied, you will be
+   prompted.
 
    Deep mode is enabled by default and records the session start time and any
    commands executed when `--start` and `--command` are supplied. Set


### PR DESCRIPTION
## Summary
- log a new session using `sl33p` to confirm chat logging works
- chat context now shows recent messages when running `w4k3`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python AGENT_tools/w4k3/o.w4k3.py --chat-limit 3 | head -n 15`
- `CHAT_IN="Test user" CHAT_OUT="Test assistant" ASSESS=a ACHIEVE=b NEXT=c CREATE=d COPY=e CONTROL=f CULTIVATE=g NARRATIVE=h python AGENT_tools/sl33p/o.sl33p.py --dry-run --chat-limit 2 | tail -n 20`
- `ASSESS="testing" ACHIEVE="ran chat tests" NEXT="none" CREATE="test" COPY="test" CONTROL="test" CULTIVATE="test" NARRATIVE="tested chat integration" CHAT_IN="Integration test message" CHAT_OUT="Integration test reply" python AGENT_tools/sl33p/o.sl33p.py --chat-limit 2`


------
https://chatgpt.com/codex/tasks/task_e_6845f0a519a083249ff289b8961e967b