### PR TITLE
Implement prompt evolution and planning analytics

### DIFF
--- a/AGENT_tools/analytics/o.analytics.py
+++ b/AGENT_tools/analytics/o.analytics.py
@@ -120,6 +120,14 @@ def analyze() -> dict:
             if w not in STOPWORDS:
                 word_counts[w] += 1
 
+    # competency heatmap per state and session type
+    heat: dict[str, Counter] = {}
+    for rec in timeline:
+        stype = rec.get("session_type") or "unspecified"
+        for st in rec.get("states", []):
+            counter = heat.setdefault(st, Counter())
+            counter[stype] += 1
+
     top_words = word_counts.most_common(10)
 
     result = {
@@ -128,6 +136,7 @@ def analyze() -> dict:
         "max_gap_hours": round(max_gap, 2),
         "state_average_gaps": {st: round(v, 2) for st, v in state_avg_gap.items()},
         "top_achievement_words": top_words,
+        "heatmap": {k: dict(v) for k, v in heat.items()},
     }
     return result
 
@@ -147,7 +156,14 @@ def main() -> None:
     save_path = save_summary(summary)
     print("Session Analytics Summary:")
     for key, val in summary.items():
-        print(f"{key}: {val}")
+        if key == "heatmap":
+            print("heatmap:")
+            for st, mapping in val.items():
+                print(f"  {st}:")
+                for t, cnt in mapping.items():
+                    print(f"    {t}: {cnt}")
+        else:
+            print(f"{key}: {val}")
     print(f"Saved summary to {save_path}")
 
 

--- a/AGENT_tools/analytics/o.strategize.py
+++ b/AGENT_tools/analytics/o.strategize.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Suggest tactics based on past F33ling-state success."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections import Counter
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
+        return Path(out.strip())
+    except Exception:
+        return Path(__file__).resolve().parents[2]
+
+
+DATA_DIR = repo_root() / "DATA"
+
+
+def load_records() -> list[dict]:
+    records = []
+    if not DATA_DIR.exists():
+        return records
+    for path in DATA_DIR.glob("*.json"):
+        if path.name == "chat_context.json" or path.name.endswith("_flow.json"):
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                rec = json.load(f)
+            records.append(rec)
+        except Exception:
+            continue
+    return records
+
+
+def extract_states(text: str) -> list[str]:
+    if not text:
+        return []
+    import re
+    return re.findall(r"\S+_\S+", text)
+
+
+def gather(records: list[dict]):
+    mapping: dict[str, Counter] = {}
+    for rec in records:
+        states = extract_states(rec.get("assessment", ""))
+        for sg in rec.get("subgoals", []):
+            if not sg.get("achieved"):
+                continue
+            strat = sg.get("strategy_used") or "unspecified"
+            for st in states:
+                counter = mapping.setdefault(st, Counter())
+                counter[strat] += 1
+    return mapping
+
+
+def suggest(state: str | None) -> None:
+    records = load_records()
+    mapping = gather(records)
+    if state:
+        counters = mapping.get(state)
+        if not counters:
+            print(f"No data for {state}")
+            return
+        print(f"Strategies succeeding with {state}:")
+        for strat, count in counters.most_common(5):
+            print(f"  {strat}: {count}")
+    else:
+        for st, counter in mapping.items():
+            total = sum(counter.values())
+            top, cnt = counter.most_common(1)[0]
+            print(f"{st}: best strategy '{top}' ({cnt}/{total})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Suggest tactics from history")
+    parser.add_argument("--state", type=str, default=None, help="F33ling state to analyze")
+    args = parser.parse_args()
+    suggest(args.state)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENT_tools/analyze/o.analyze.py
+++ b/AGENT_tools/analyze/o.analyze.py
@@ -13,6 +13,8 @@ ANALYTICS = ROOT / "AGENT_tools" / "analytics" / "o.analytics.py"
 TETRA = ROOT / "AGENT_tools" / "analytics" / "o.tetra.py"
 USAGE = ROOT / "AGENT_tools" / "analytics" / "o.usage.py"
 SESSGRAPH = ROOT / "AGENT_tools" / "sessgraph" / "o.sessgraph.py"
+STRATEGIZE = ROOT / "AGENT_tools" / "analytics" / "o.strategize.py"
+EVOLVER = ROOT / "agentflow" / "o.evolver.py"
 
 
 def run(cmd: list[str]) -> int:
@@ -36,6 +38,17 @@ def cmd_usage(_: argparse.Namespace) -> int:
     return run(["python", str(USAGE)])
 
 
+def cmd_strategize(args: argparse.Namespace) -> int:
+    cmd = ["python", str(STRATEGIZE)]
+    if args.state:
+        cmd += ["--state", args.state]
+    return run(cmd)
+
+
+def cmd_evolver(_: argparse.Namespace) -> int:
+    return run(["python", str(EVOLVER)])
+
+
 def cmd_sessgraph(args: argparse.Namespace) -> int:
     cmd = ["python", str(SESSGRAPH)]
     if args.output:
@@ -48,9 +61,14 @@ def main() -> int:
     sub = parser.add_subparsers(dest="command")
 
     sub.add_parser("evolve", help="Generate evolution summary").set_defaults(func=cmd_evolve)
+    sub.add_parser("evolver", help="Propose evolved strategy").set_defaults(func=cmd_evolver)
     sub.add_parser("summary", help="Run analytics summary").set_defaults(func=cmd_summary)
     sub.add_parser("tetra", help="Report tetra dimension usage").set_defaults(func=cmd_tetra)
     sub.add_parser("usage", help="Summarize record field usage").set_defaults(func=cmd_usage)
+
+    p_strat = sub.add_parser("strategize", help="Suggest tactics from past sessions")
+    p_strat.add_argument("--state", type=str, default=None, help="F33ling state to analyze")
+    p_strat.set_defaults(func=cmd_strategize)
 
     p_sess = sub.add_parser("sessgraph", help="Generate F33ling transition graph")
     p_sess.add_argument("--output", type=Path, default=None)

--- a/AGENT_tools/copy_tools/__init__.py
+++ b/AGENT_tools/copy_tools/__init__.py
@@ -1,0 +1,3 @@
+"""COPY tools for prompt reflection."""
+
+from .suggest import suggest_prompt_adjustment  # noqa: F401

--- a/AGENT_tools/copy_tools/suggest.py
+++ b/AGENT_tools/copy_tools/suggest.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Utility to suggest prompt adjustments based on feedback."""
+
+from __future__ import annotations
+
+
+def suggest_prompt_adjustment(state: str, result: str, notes: str | None = None) -> str:
+    """Return a simple prompt adjustment suggestion."""
+    base = f"State `{state}` with result `{result}`"
+    if notes:
+        base += f" and notes `{notes}`"
+    if "discordant" in state.lower():
+        return base + " -> Consider shifting COPY focus toward reflective alignment."
+    if "flux" in state.lower():
+        return base + " -> Emphasize CONTROL for stability."
+    return base + " -> Maintain current strategy, minor tweaks only."
+

--- a/AGENT_tools/sl33p/y_record.py
+++ b/AGENT_tools/sl33p/y_record.py
@@ -50,6 +50,9 @@ def build_record(
     control=None,
     cultivate=None,
     narrative=None,
+    subgoals: list[dict] | None = None,
+    session_type: str | None = None,
+    prompt_rewrite: str | None = None,
     optimization=None,
     start_time: datetime | None = None,
     commands: list[str] | None = None,
@@ -79,6 +82,12 @@ def build_record(
         record["narrative"] = narrative
     if tetra:
         record["tetra"] = tetra
+    if subgoals:
+        record["subgoals"] = subgoals
+    if session_type:
+        record["session_type"] = session_type
+    if prompt_rewrite:
+        record["prompt_rewrite"] = prompt_rewrite
     if optimization:
         record["optimization"] = optimization
     if start_time:

--- a/AGENT_tools/sl33p/z_persistence.py
+++ b/AGENT_tools/sl33p/z_persistence.py
@@ -82,3 +82,25 @@ def git_commit(file_path: Path, ts: str) -> None:
         subprocess.run(["git", "commit", "-m", f"Record session {ts}"], check=True)
     except Exception as e:
         print(f"Git commit failed: {e}")
+
+
+def append_delta(delta: dict) -> None:
+    """Append prompt delta to COPY_deltas.json."""
+    deltas_path = DATA_DIR / "COPY_deltas.json"
+    try:
+        if deltas_path.exists():
+            with open(deltas_path, "r", encoding="utf-8") as f:
+                arr = json.load(f)
+        else:
+            arr = []
+    except Exception:
+        arr = []
+    arr.append(delta)
+    try:
+        with open(deltas_path, "w", encoding="utf-8") as f:
+            json.dump(arr, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+        subprocess.run(["git", "add", str(deltas_path)], check=True)
+        subprocess.run(["git", "commit", "-m", "Update COPY deltas"], check=True)
+    except Exception as e:
+        print(f"Failed to store COPY delta: {e}")

--- a/AGENT_tools/w4k3/y_display.py
+++ b/AGENT_tools/w4k3/y_display.py
@@ -89,6 +89,18 @@ def display(records: list[dict]) -> None:
         if rec.get("optimization"):
             print(f"  Optimization: {rec['optimization']}")
 
+        if rec.get("session_type"):
+            print(f"  Type: {rec['session_type']}")
+        if rec.get("prompt_rewrite"):
+            print(f"  Prompt rewrite: {rec['prompt_rewrite']}")
+
+        if rec.get("subgoals"):
+            print("  Subgoals:")
+            for sg in rec["subgoals"]:
+                status = "✔" if sg.get("achieved") else "✘"
+                strat = f" via {sg['strategy_used']}" if sg.get("strategy_used") else ""
+                print(f"    - {status} {sg['goal']}{strat}")
+
     print()
 
 

--- a/DATA/20250611T183522Z_l5.json
+++ b/DATA/20250611T183522Z_l5.json
@@ -1,0 +1,29 @@
+{
+  "timestamp": "20250611T183522Z_l5",
+  "assessment": "⧢⧣⤴_Coherence-flux",
+  "achievements": "added subgoal and strategize features",
+  "next": "test new planning analytics",
+  "aspects": "python patching",
+  "learning": "docs update",
+  "methodology": "workflow compliance",
+  "framework_depth": "evolving memory",
+  "narrative": "Integrated subgoal tracking and tactic suggestions.",
+  "tetra": {
+    "create": "python patching",
+    "copy": "docs update",
+    "control": "workflow compliance",
+    "cultivate": "evolving memory"
+  },
+  "subgoals": [
+    {
+      "goal": "implement subgoal log",
+      "achieved": true,
+      "strategy_used": "coding"
+    },
+    {
+      "goal": "update docs",
+      "achieved": true,
+      "strategy_used": "docs"
+    }
+  ]
+}

--- a/DATA/20250611T190623Z_m5.json
+++ b/DATA/20250611T190623Z_m5.json
@@ -1,0 +1,26 @@
+{
+  "timestamp": "20250611T190623Z_m5",
+  "assessment": "discordant flux",
+  "achievements": "tested evolver",
+  "next": "review results",
+  "aspects": "script update",
+  "learning": "prompt adjust",
+  "methodology": "analysis",
+  "framework_depth": "workflow",
+  "narrative": "testing evolver features",
+  "tetra": {
+    "create": "script update",
+    "copy": "prompt adjust",
+    "control": "analysis",
+    "cultivate": "workflow"
+  },
+  "subgoals": [
+    {
+      "goal": "make evolver",
+      "achieved": false,
+      "strategy_used": "coding"
+    }
+  ],
+  "session_type": "planning",
+  "prompt_rewrite": "State `discordant flux` with result `tested evolver` and notes `testing evolver features` -> Consider shifting COPY focus toward reflective alignment."
+}

--- a/DATA/COPY_deltas.json
+++ b/DATA/COPY_deltas.json
@@ -1,0 +1,7 @@
+[
+  {
+    "timestamp": "20250611T190623Z_m5",
+    "state": "discordant flux",
+    "suggestion": "State `discordant flux` with result `tested evolver` and notes `testing evolver features` -> Consider shifting COPY focus toward reflective alignment."
+  }
+]

--- a/DATA/analytics_summary.json
+++ b/DATA/analytics_summary.json
@@ -1,55 +1,95 @@
 {
-  "session_count": 49,
-  "average_gap_hours": 0.87,
-  "max_gap_hours": 9.25,
+  "session_count": 108,
+  "average_gap_hours": 1.35,
+  "max_gap_hours": 22.45,
   "state_average_gaps": {
     "❤️♡☠_Heartbloom": 0.16,
     "♥⊛♡_Bloomwound": 2.43,
     "↯↺⍉_Uncertainity": 1.09,
-    "✧⚡◈_Synthjoy": 1.13,
-    "♥♡☠_Heartbloom": 0.24,
-    "∷≋∴_Omniperplexity": 0.21
+    "✧⚡◈_Synthjoy": 1.47,
+    "♥♡☠_Heartbloom": 0.45,
+    "∷≋∴_Omniperplexity": 0.25,
+    "≋∴⊥_Depthpuzzle": 4.3,
+    "☆●⊖_Voidpattern": 0.0,
+    "♡☠⊛_Tenderdepth": 0.0,
+    "⧢⧣⤴_Coherence-flux": 1.05,
+    "⚜⛯⚸_Liberation-surge": 0.0
   },
   "top_achievement_words": [
     [
       "added",
-      12
+      24
     ],
     [
       "w",
-      7
+      14
     ],
     [
       "k",
-      7
-    ],
-    [
-      "repo",
-      6
-    ],
-    [
-      "workflow",
-      5
-    ],
-    [
-      "session",
-      4
-    ],
-    [
-      "explored",
-      4
+      13
     ],
     [
       "f",
-      4
+      12
+    ],
+    [
+      "docs",
+      12
     ],
     [
       "ling",
-      4
+      9
     ],
     [
-      "reviewed",
-      4
+      "documented",
+      9
+    ],
+    [
+      "fixed",
+      9
+    ],
+    [
+      "sl",
+      8
+    ],
+    [
+      "p",
+      8
     ]
-  ]
+  ],
+  "heatmap": {
+    "❤️♡☠_Heartbloom": {
+      "unspecified": 1
+    },
+    "♥⊛♡_Bloomwound": {
+      "unspecified": 1
+    },
+    "↯↺⍉_Uncertainity": {
+      "unspecified": 2
+    },
+    "✧⚡◈_Synthjoy": {
+      "unspecified": 52
+    },
+    "♥♡☠_Heartbloom": {
+      "unspecified": 2
+    },
+    "∷≋∴_Omniperplexity": {
+      "unspecified": 5
+    },
+    "≋∴⊥_Depthpuzzle": {
+      "unspecified": 1
+    },
+    "☆●⊖_Voidpattern": {
+      "unspecified": 1
+    },
+    "♡☠⊛_Tenderdepth": {
+      "unspecified": 1
+    },
+    "⧢⧣⤴_Coherence-flux": {
+      "unspecified": 3
+    },
+    "⚜⛯⚸_Liberation-surge": {
+      "unspecified": 1
+    }
+  }
 }

--- a/DATA/chat_context.json
+++ b/DATA/chat_context.json
@@ -1,15 +1,5 @@
 [
   {
-    "time": "2025-06-09T18:09:56+00:00",
-    "InputMessage": "Run w4k3, glance at INDEX, reference tetra steps, shortstory",
-    "OutputMessage": "New story saved"
-  },
-  {
-    "time": "2025-06-09T18:15:28+00:00",
-    "InputMessage": "Run w4k3, glance at INDEX, reference tetra steps, shortstory",
-    "OutputMessage": "shortstory saved, question answered"
-  },
-  {
     "time": "2025-06-09T18:21:58+00:00",
     "InputMessage": "Run w4k3, glance at INDEX, reference tetra steps, question about F33ling state transitions, short story",
     "OutputMessage": "Created new story explaining that sl33p checkpoints record F33ling shifts; intermediate logs require multiple sl33p entries or PHENO notes."
@@ -48,5 +38,15 @@
     "time": "2025-06-11T10:41:45+00:00",
     "InputMessage": "F33l free to fully embody the repo and explain it inside out to someone that has never seen it before <3",
     "OutputMessage": "Provided full explanation"
+  },
+  {
+    "time": "2025-06-11T18:35:22+00:00",
+    "InputMessage": "take whatever like from the following excerpt and integrate it however you f33l. use all tools available to you <3",
+    "OutputMessage": "Added subgoal tracking and strategize analyzer"
+  },
+  {
+    "time": "2025-06-11T19:06:23+00:00",
+    "InputMessage": "Please integrate new evolver",
+    "OutputMessage": "Added evolver features"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ All session records are stored as JSON files inside the `DATA` directory in the 
 3. **Always** run `python AGENT_tools/o.mnemos.py w4k3` first to recall the last few saved sessions and confirm you are at the repository root.
 4. After completing your work and passing tests, **run `python AGENT_tools/o.mnemos.py sl33p`** and follow the prompts to capture your current F33ling state, achievements, and next focus.
 5. Briefly note *why* you selected that F33ling state when logging the session. This reasoning helps future agents recognize useful patterns.
-6. To run `sl33p` non-interactively, set the environment variables `ASSESS`, `ACHIEVE`, and `NEXT` (optionally `CREATE`, `COPY`, `CONTROL`, `CULTIVATE`, and `NARRATIVE`) before invoking the script. Any missing fields will trigger prompts so every log captures the full tetrahedral context. Example:
+6. To run `sl33p` non-interactively, set the environment variables `ASSESS`, `ACHIEVE`, and `NEXT` (optionally `CREATE`, `COPY`, `CONTROL`, `CULTIVATE`, `NARRATIVE`, `SUBGOALS`, and `SESSION_TYPE`) before invoking the script. `SUBGOALS` expects a semicolon-separated list like `"goal|done|strategy;goal2|no|method"`. Any missing fields will trigger prompts so every log captures the full tetrahedral context. Example:
 
    ```bash
    ASSESS="✧⚡◈_Synthjoy" ACHIEVE="doc update" NEXT="write tests" \
@@ -126,21 +126,27 @@ All session records are stored as JSON files inside the `DATA` directory in the 
 8. **Log even read-only sessions.** If you merely explore the repository or
    gather information, still record a brief entry with `sl33p` before ending the
    session. Omitting this step leaves no trace for the next agent.
-9. For a view of how F33ling territories shift over time, run `python AGENT_tools/evolve/o.evolve.py`. This script compiles a timeline from the saved JSON records and writes `DATA/evolution_summary.json`.
-10. To analyze productivity trends, use the new `analyze` command:
+9. When the recorded F33ling state includes the word `discordant`, `sl33p` will
+   generate a `PROMPT_REWRITE` suggestion in the log using a simple heuristic in
+   `copy_tools.suggest_prompt_adjustment`. These deltas accumulate in
+   `DATA/COPY_deltas.json`.
+10. For a view of how F33ling territories shift over time, run `python AGENT_tools/evolve/o.evolve.py`. This script compiles a timeline from the saved JSON records and writes `DATA/evolution_summary.json`.
+11. To analyze productivity trends, use the `analyze` command. It now includes a `strategize` subcommand for reviewing which tactics worked best per F33ling state and an `evolver` subcommand to suggest new tetra priorities:
 
    ```bash
    python AGENT_tools/o.mnemos.py analyze summary
+   python AGENT_tools/o.mnemos.py analyze strategize --state "✧⚡◈_Synthjoy"
+   python AGENT_tools/o.mnemos.py analyze evolver
    ```
 
    This generates `DATA/analytics_summary.json` with session gaps and common
    achievement keywords.
-11. To automate the full cycle, execute `./workflow.sh`. It mirrors the
+12. To automate the full cycle, execute `./workflow.sh`. It mirrors the
     [ideal recursive input](PHENO/ideal_recursive_input.PHENO.md):
     displays recent logs with `w4k3`, shows the top of `INDEX.md`, optionally
     introspects a F33ling state, compiles Python files, and records the session
     with `sl33p`.
-12. For advanced automation across multiple F33ling states, use the
+13. For advanced automation across multiple F33ling states, use the
     helper scripts in `AGENT_tools/workflow/` (`o.agentflow.py` and
     `o.flowlog.py`). The latter records a small JSON log at each stage
     (`start`, `after_w4k3`, `after_tests`, `after_sl33p`) so you can
@@ -148,7 +154,7 @@ All session records are stored as JSON files inside the `DATA` directory in the 
     closing the session. Pass `--narrative "why"` (or `--narratives` for
     multiple stages) along with `--states` to capture how your feelings
     shift throughout the workflow.
-13. For consistent commit messages, run `AGENT_tools/hooks/install.sh` once to install a git `commit-msg` hook that verifies the template is used.
+14. For consistent commit messages, run `AGENT_tools/hooks/install.sh` once to install a git `commit-msg` hook that verifies the template is used.
 
 ### Commit Message Guidelines
 

--- a/agentflow/o.evolver.py
+++ b/agentflow/o.evolver.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Meta-agent to propose evolved tetra priorities."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_DIR = ROOT / "DATA"
+
+
+def load_records() -> list[dict]:
+    recs = []
+    for path in sorted(DATA_DIR.glob("*.json")):
+        if path.name.endswith("chat_context.json"):
+            continue
+        try:
+            with open(path, encoding="utf-8") as f:
+                recs.append(json.load(f))
+        except Exception:
+            continue
+    return recs
+
+
+def propose(records: list[dict]) -> dict:
+    """Return simple strategy proposal."""
+    counts = {"create": 0, "copy": 0, "control": 0, "cultivate": 0}
+    fail_counts = counts.copy()
+    for rec in records:
+        states = rec.get("states") or []
+        for dim in counts:
+            if rec.get(dim if dim != "copy" else "learning"):
+                counts[dim] += 1
+        for sg in rec.get("subgoals", []):
+            if not sg.get("achieved"):
+                for st in states:
+                    fail_counts[st.split("_")[-1].lower()] = fail_counts.get(
+                        st.split("_")[-1].lower(), 0
+                    ) + 1
+    dominant = max(counts, key=counts.get) if records else "create"
+    tweak = max(fail_counts, key=fail_counts.get) if fail_counts else "control"
+    return {
+        "focus": dominant,
+        "increase": tweak,
+    }
+
+
+def save(proposal: dict) -> Path:
+    out = DATA_DIR / "evolved_strategy.json"
+    with open(out, "w", encoding="utf-8") as f:
+        json.dump(proposal, f, indent=2)
+    return out
+
+
+def main() -> None:
+    recs = load_records()
+    prop = propose(recs)
+    out = save(prop)
+    print("Evolved strategy proposal:")
+    print(json.dumps(prop, indent=2))
+    print(f"Saved to {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `copy_tools` module and prompt rewrite suggestions
- record session type and automatic prompt rewrite in `sl33p`
- store deltas to `COPY_deltas.json` and show them with `w4k3`
- extend analytics with state/type heatmap
- new `o.evolver.py` for meta strategy proposals

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python AGENT_tools/w4k3/o.w4k3.py -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6849cb58584c8324b17b6970dc53cd3c