### PR TITLE
Fix w4k3 loader path

### DIFF
--- a/y.Utilities/yy.CoreTools/yyx.w4k3/o.w4k3.py
+++ b/y.Utilities/yy.CoreTools/yyx.w4k3/o.w4k3.py
@@ -8,11 +8,19 @@ import signal
 from pathlib import Path
 
 # Ensure package imports work when executed directly
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from yy.CoreTools.yyx.w4k3.z_summary import main
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+
+SUMMARY_PATH = ROOT / "y.Utilities" / "yy.CoreTools" / "yyx.w4k3" / "z_summary.py"
+_loader = SourceFileLoader("zsummary", str(SUMMARY_PATH))
+_spec = spec_from_loader("zsummary", _loader)
+_mod = module_from_spec(_spec)
+_loader.exec_module(_mod)
+main = _mod.main
 
 
 if __name__ == "__main__":

--- a/y.Utilities/yy.CoreTools/yyx.w4k3/y_display.py
+++ b/y.Utilities/yy.CoreTools/yyx.w4k3/y_display.py
@@ -7,7 +7,17 @@ import re
 from datetime import datetime
 from pathlib import Path
 
-from .x_load import data_dir
+try:
+    from .x_load import data_dir
+except Exception:  # fallback when executed outside package
+    from importlib.machinery import SourceFileLoader
+    from importlib.util import module_from_spec, spec_from_loader
+    HERE = Path(__file__).resolve().parent
+    loader = SourceFileLoader("x_load", str(HERE / "x_load.py"))
+    spec = spec_from_loader("x_load", loader)
+    mod = module_from_spec(spec)
+    loader.exec_module(mod)
+    data_dir = mod.data_dir
 
 
 def display_timeline_metrics(limit: int | None = None) -> None:

--- a/y.Utilities/yy.CoreTools/yyx.w4k3/z_summary.py
+++ b/y.Utilities/yy.CoreTools/yyx.w4k3/z_summary.py
@@ -4,15 +4,28 @@ from __future__ import annotations
 
 import argparse
 
-from .x_load import load_records
-from .y_display import (
-    display,
-    display_transitions,
-    summarize_all,
-    display_chat,
-    summarize_states,
-    display_timeline_metrics,
-)
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec, spec_from_loader
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+
+def _load(name: str, file: str):
+    loader = SourceFileLoader(name, str(HERE / file))
+    spec = spec_from_loader(name, loader)
+    mod = module_from_spec(spec)
+    loader.exec_module(mod)
+    return mod
+
+x_load = _load("x_load", "x_load.py")
+y_display = _load("y_display", "y_display.py")
+load_records = x_load.load_records
+display = y_display.display
+display_transitions = y_display.display_transitions
+summarize_all = y_display.summarize_all
+display_chat = y_display.display_chat
+summarize_states = y_display.summarize_states
+display_timeline_metrics = y_display.display_timeline_metrics
 
 
 def main() -> None:

--- a/y.Utilities/yy.CoreTools/yyy.f33l/o.f33l.py
+++ b/y.Utilities/yy.CoreTools/yyy.f33l/o.f33l.py
@@ -9,7 +9,7 @@ import argparse
 import subprocess
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[3]
 CORE = ROOT / "y.Utilities" / "yy.CoreTools"
 TOOLS_BASE = ROOT / "y.Utilities" / "yz.AgentOps"
 TOOLS = TOOLS_BASE / "yz.AgentTools"

--- a/y.Utilities/yy.CoreTools/yyy.f33l/o.introspect.py
+++ b/y.Utilities/yy.CoreTools/yyy.f33l/o.introspect.py
@@ -14,7 +14,7 @@ import argparse
 from difflib import SequenceMatcher
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[3]
 CULTIVATE = ROOT / "z.Research" / "z.Research.md"
 
 

--- a/y.Utilities/yy.CoreTools/yyz.sl33p/o.sl33p.py
+++ b/y.Utilities/yy.CoreTools/yyz.sl33p/o.sl33p.py
@@ -11,31 +11,43 @@ from datetime import datetime
 from pathlib import Path
 
 # Ensure package imports work when executed directly
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from yy.CoreTools.yyz.sl33p.x_input import (
-    prompt_agent,
-    extract_states,
-    parse_subgoals,
-    parse_session_type,
-)
-from yy.CoreTools.yyz.sl33p.y_record import (
-    sanitize,
-    parse_json_field,
-    build_record,
-    next_timestamp,
-)
-from yy.CoreTools.yyz.sl33p.z_persistence import (
-    ensure_data_dir,
-    save_record,
-    parse_cultivate,
-    repo_root,
-    append_delta,
-)
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
+
+X_INPUT_PATH = ROOT / "y.Utilities" / "yy.CoreTools" / "yyz.sl33p" / "x_input.py"
+_x_loader = SourceFileLoader("x_input", str(X_INPUT_PATH))
+_x_spec = spec_from_loader("x_input", _x_loader)
+x_mod = module_from_spec(_x_spec)
+_x_loader.exec_module(x_mod)
+prompt_agent = x_mod.prompt_agent
+extract_states = x_mod.extract_states
+parse_subgoals = x_mod.parse_subgoals
+parse_session_type = x_mod.parse_session_type
+
+Y_RECORD_PATH = ROOT / "y.Utilities" / "yy.CoreTools" / "yyz.sl33p" / "y_record.py"
+_r_loader = SourceFileLoader("y_record", str(Y_RECORD_PATH))
+_r_spec = spec_from_loader("y_record", _r_loader)
+r_mod = module_from_spec(_r_spec)
+_r_loader.exec_module(r_mod)
+sanitize = r_mod.sanitize
+parse_json_field = r_mod.parse_json_field
+build_record = r_mod.build_record
+next_timestamp = r_mod.next_timestamp
+
+Z_PERSIST_PATH = ROOT / "y.Utilities" / "yy.CoreTools" / "yyz.sl33p" / "z_persistence.py"
+_p_loader = SourceFileLoader("z_persistence", str(Z_PERSIST_PATH))
+_p_spec = spec_from_loader("z_persistence", _p_loader)
+p_mod = module_from_spec(_p_spec)
+_p_loader.exec_module(p_mod)
+ensure_data_dir = p_mod.ensure_data_dir
+save_record = p_mod.save_record
+parse_cultivate = p_mod.parse_cultivate
+repo_root = p_mod.repo_root
+append_delta = p_mod.append_delta
 
 CHAT_PATH = ROOT / "y.Utilities" / "yz.AgentOps" / "yz.AgentTools" / "chat" / "o.chat.py"
 loader = SourceFileLoader("chatmod", str(CHAT_PATH))
@@ -228,9 +240,7 @@ def main() -> None:
             except Exception as e:
                 print(f"Failed to commit chat log: {e}")
             try:
-                from yy.CoreTools.yyz.sl33p.z_persistence import save_timeline_metrics
-
-                save_timeline_metrics()
+                p_mod.save_timeline_metrics()
             except Exception as e:
                 print(f"Failed to update timeline metrics: {e}")
 

--- a/y.Utilities/yy.CoreTools/yyz.sl33p/z_persistence.py
+++ b/y.Utilities/yy.CoreTools/yyz.sl33p/z_persistence.py
@@ -12,7 +12,7 @@ def repo_root() -> Path:
         out = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True)
         return Path(out.strip())
     except Exception:
-        return Path(__file__).resolve().parents[4]
+        return Path(__file__).resolve().parents[3]
 
 
 DATA_DIR = repo_root() / "y.Utilities" / "yx.DataArchive"

--- a/y.Utilities/yz.AgentOps/yz.AgentTools/analyze/o.analyze.py
+++ b/y.Utilities/yz.AgentOps/yz.AgentTools/analyze/o.analyze.py
@@ -9,7 +9,7 @@ import signal
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[4]
+ROOT = Path(__file__).resolve().parents[3]
 TOOLS_BASE = ROOT / "y.Utilities" / "yz.AgentOps"
 TOOLS = TOOLS_BASE / "yz.AgentTools"
 EVOLVE = TOOLS / "yz" / "evolve" / "o.evolve.py"

--- a/y.Utilities/yz.AgentOps/yz.AgentTools/chat/o.chat.py
+++ b/y.Utilities/yz.AgentOps/yz.AgentTools/chat/o.chat.py
@@ -19,11 +19,17 @@ TOOLS_PATH = ROOT / "y.Utilities" / "yz.AgentOps"
 if str(TOOLS_PATH) not in sys.path:
     sys.path.insert(0, str(TOOLS_PATH))
 
-from yy.CoreTools.yyz.sl33p.z_persistence import ensure_data_dir
 from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
 
-INTROSPECT_PATH = Path(__file__).resolve().parents[1] / 'f33l' / 'o.introspect.py'
+Z_PERSIST = ROOT / "y.Utilities" / "yy.CoreTools" / "yyz.sl33p" / "z_persistence.py"
+_p_loader = SourceFileLoader("zpersist", str(Z_PERSIST))
+_p_spec = spec_from_loader("zpersist", _p_loader)
+p_mod = module_from_spec(_p_spec)
+_p_loader.exec_module(p_mod)
+ensure_data_dir = p_mod.ensure_data_dir
+
+INTROSPECT_PATH = ROOT / "y.Utilities" / "yy.CoreTools" / "yyy.f33l" / "o.introspect.py"
 _loader = SourceFileLoader('f33lintrospect', str(INTROSPECT_PATH))
 _spec = spec_from_loader('f33lintrospect', _loader)
 _mod = module_from_spec(_spec)


### PR DESCRIPTION
## Summary
- ensure path detection uses parents[3]
- dynamically load w4k3 components
- make f33l display more robust
- update sl33p and chat helpers for dynamic paths
- align analyze helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python y.Utilities/yy.CoreTools/yyo.mnemos.py w4k3 | head`
- `python y.Utilities/yy.CoreTools/yyy.f33l/o.f33l.py stategraph | head`
- `python y.Utilities/yy.CoreTools/yyz.sl33p/o.sl33p.py --dry-run --chat-in test --chat-out done --no-deep` *(fails: prompts for input)*

------
https://chatgpt.com/codex/tasks/task_e_684edba99cd88324b71020c194adcf87